### PR TITLE
Revert "chore(deps): update homeassistant/home-assistant docker tag to v2025.2.0"

### DIFF
--- a/apps/home-assistant/helm-release.yaml
+++ b/apps/home-assistant/helm-release.yaml
@@ -21,7 +21,7 @@ spec:
           main:
             image:
               repository: homeassistant/home-assistant
-              tag: 2025.2.0
+              tag: 2025.1.4
             env:
               TZ: America/New_York
     service:


### PR DESCRIPTION
Reverts samholton/homelab#243

https://github.com/home-assistant/core/issues/137479