### PR TITLE
Revert "chore(deps): update helm release ingress-nginx to v4.13.0"

### DIFF
--- a/infrastructure/ingress-nginx/helm-release.yaml
+++ b/infrastructure/ingress-nginx/helm-release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: ingress-nginx
-      version: '4.13.0'
+      version: '4.12.3'
       sourceRef:
         kind: HelmRepository
         name: ingress-nginx
@@ -40,7 +40,7 @@ spec:
   chart:
     spec:
       chart: ingress-nginx
-      version: '4.13.0'
+      version: '4.12.3'
       sourceRef:
         kind: HelmRepository
         name: ingress-nginx


### PR DESCRIPTION
Reverts samholton/homelab#449

```
E0709 02:44:01.236123       7 queue.go:131] "requeuing" err=<

    -------------------------------------------------------------------------------
    Error: exit status 1
    2025/07/09 02:44:01 [emerg] 40#40: "proxy_busy_buffers_size" must be equal to or greater than the maximum of the value of "proxy_buffer_size" and one of the "proxy_buffers" in /tmp/nginx/nginx-cfg2047974998:1869
    nginx: [emerg] "proxy_busy_buffers_size" must be equal to or greater than the maximum of the value of "proxy_buffer_size" and one of the "proxy_buffers" in /tmp/nginx/nginx-cfg2047974998:1869
    nginx: configuration file /tmp/nginx/nginx-cfg2047974998 test failed
```